### PR TITLE
Update token on setup repo to retrieve from secrets PAT

### DIFF
--- a/.github/workflows/build-mobile-preview.yml
+++ b/.github/workflows/build-mobile-preview.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GH_PAT }}
           repository: Futurepet/pasture
           fetch-depth: 0
       - name: 🏗 Setup Node


### PR DESCRIPTION
We need to retrieve the token by a personal access token according to this [documentation](https://github.com/actions/checkout#checkout-multiple-repos-private)